### PR TITLE
fix: action only fetches most recent 30 issues on github

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8393,6 +8393,7 @@ function run() {
                 if (validateIssue(issue, target))
                     ++count;
             }
+            core.info(key + count.toString());
             members.set(key, count);
         }));
         // determine team member with fewest assigned issues/PRs

--- a/dist/index.js
+++ b/dist/index.js
@@ -8345,19 +8345,6 @@ function run() {
         const team = core.getInput('team');
         const exemptTeam = core.getInput('exempt-team', { required: false });
         const octokit = github.getOctokit(token);
-        // set issue type to count
-        const thisIssueData = yield octokit.rest.issues.get({
-            owner: github.context.repo.owner,
-            repo: github.context.repo.repo,
-            issue_number: github.context.issue.number,
-        });
-        let target = '';
-        if (thisIssueData.data.pull_request) {
-            target = 'pull_requests';
-        }
-        else {
-            target = 'issues';
-        }
         // Check if issue was submitted by exempt team member
         if (exemptTeam) {
             const exemptMemberData = yield octokit.rest.teams.listMembersInOrg({
@@ -8370,6 +8357,19 @@ function run() {
                     return;
                 }
             }
+        }
+        // set issue type to count
+        const thisIssueData = yield octokit.rest.issues.get({
+            owner: github.context.repo.owner,
+            repo: github.context.repo.repo,
+            issue_number: github.context.issue.number,
+        });
+        let target = '';
+        if (thisIssueData.data.pull_request) {
+            target = 'pull_requests';
+        }
+        else {
+            target = 'issues';
         }
         // get list of members on team
         const memberData = yield octokit.rest.teams.listMembersInOrg({
@@ -8393,24 +8393,9 @@ function run() {
                 if (validateIssue(issue, target))
                     ++count;
             }
-            core.info(key + ' ' + count.toString());
+            core.info(key + ' has ' + count.toString() + ' ' + target + ' assigned to them.');
             members.set(key, count);
         }
-        // get number of issues/PRs assigned per team member
-        // members.forEach(async (value: number, key: string) => {
-        //   const { data } = await octokit.rest.issues.listForRepo({
-        //     owner: github.context.repo.owner,
-        //     repo: github.context.repo.repo,
-        //     assignee: key,
-        //     per_page: 100,
-        //   });
-        //   let count: number = 0;
-        //   for (const issue of data) {
-        //     if (validateIssue(issue, target)) ++count;
-        //   }
-        //   core.info(key + ' ' + count.toString());
-        //   members.set(key, count);
-        // });
         // determine team member with fewest assigned issues/PRs
         let winner = '';
         let low;

--- a/dist/index.js
+++ b/dist/index.js
@@ -8381,23 +8381,19 @@ function run() {
             members.set(member.login, 0);
         }
         // get number of issues/PRs assigned per team member
-        const issueData = yield octokit.rest.issues.listForRepo({
-            owner: github.context.repo.owner,
-            repo: github.context.repo.repo,
-        });
-        for (const issue of issueData.data) {
-            if (!validateIssue(issue, target)) {
-                continue;
+        members.forEach((value, key) => __awaiter(this, void 0, void 0, function* () {
+            const { data } = yield octokit.rest.issues.listForRepo({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                assignee: key
+            });
+            let count = 0;
+            for (const issue of data) {
+                if (validateIssue(issue, target))
+                    ++count;
             }
-            if (issue.assignees) {
-                for (const assignee of issue.assignees) {
-                    let val = members.get(assignee.login);
-                    if (val !== undefined) {
-                        members.set(assignee.login, ++val);
-                    }
-                }
-            }
-        }
+            members.set(key, count);
+        }));
         // determine team member with fewest assigned issues/PRs
         let winner = '';
         let low;

--- a/dist/index.js
+++ b/dist/index.js
@@ -8385,7 +8385,8 @@ function run() {
             const { data } = yield octokit.rest.issues.listForRepo({
                 owner: github.context.repo.owner,
                 repo: github.context.repo.repo,
-                assignee: key
+                assignee: key,
+                per_page: 100,
             });
             let count = 0;
             for (const issue of data) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -8381,7 +8381,7 @@ function run() {
             members.set(member.login, 0);
         }
         // get number of issues/PRs assigned per team member
-        members.forEach((value, key) => __awaiter(this, void 0, void 0, function* () {
+        yield members.forEach((value, key) => __awaiter(this, void 0, void 0, function* () {
             const { data } = yield octokit.rest.issues.listForRepo({
                 owner: github.context.repo.owner,
                 repo: github.context.repo.repo,
@@ -8393,7 +8393,7 @@ function run() {
                 if (validateIssue(issue, target))
                     ++count;
             }
-            core.info(key + count.toString());
+            core.info(key + ' ' + count.toString());
             members.set(key, count);
         }));
         // determine team member with fewest assigned issues/PRs

--- a/dist/index.js
+++ b/dist/index.js
@@ -8381,7 +8381,7 @@ function run() {
             members.set(member.login, 0);
         }
         // get number of issues/PRs assigned per team member
-        yield members.forEach((value, key) => __awaiter(this, void 0, void 0, function* () {
+        for (const [key, value] of members) {
             const { data } = yield octokit.rest.issues.listForRepo({
                 owner: github.context.repo.owner,
                 repo: github.context.repo.repo,
@@ -8395,7 +8395,22 @@ function run() {
             }
             core.info(key + ' ' + count.toString());
             members.set(key, count);
-        }));
+        }
+        // get number of issues/PRs assigned per team member
+        // members.forEach(async (value: number, key: string) => {
+        //   const { data } = await octokit.rest.issues.listForRepo({
+        //     owner: github.context.repo.owner,
+        //     repo: github.context.repo.repo,
+        //     assignee: key,
+        //     per_page: 100,
+        //   });
+        //   let count: number = 0;
+        //   for (const issue of data) {
+        //     if (validateIssue(issue, target)) ++count;
+        //   }
+        //   core.info(key + ' ' + count.toString());
+        //   members.set(key, count);
+        // });
         // determine team member with fewest assigned issues/PRs
         let winner = '';
         let low;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ async function run() {
     for (const issue of data) {
       if (validateIssue(issue, target)) ++count;
     }
+    core.info(key + count.toString());
     members.set(key, count);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ async function run() {
   }
 
   // get number of issues/PRs assigned per team member
-  members.forEach(async (value: number, key: string) => {
+  await members.forEach(async (value: number, key: string) => {
     const { data } = await octokit.rest.issues.listForRepo({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
@@ -56,7 +56,7 @@ async function run() {
     for (const issue of data) {
       if (validateIssue(issue, target)) ++count;
     }
-    core.info(key + count.toString());
+    core.info(key + ' ' + count.toString());
     members.set(key, count);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ async function run() {
   }
 
   // get number of issues/PRs assigned per team member
-  await members.forEach(async (value: number, key: string) => {
+  for (const [key, value] of members) {
     const { data } = await octokit.rest.issues.listForRepo({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
@@ -58,7 +58,23 @@ async function run() {
     }
     core.info(key + ' ' + count.toString());
     members.set(key, count);
-  });
+  }
+
+  // get number of issues/PRs assigned per team member
+  // members.forEach(async (value: number, key: string) => {
+  //   const { data } = await octokit.rest.issues.listForRepo({
+  //     owner: github.context.repo.owner,
+  //     repo: github.context.repo.repo,
+  //     assignee: key,
+  //     per_page: 100,
+  //   });
+  //   let count: number = 0;
+  //   for (const issue of data) {
+  //     if (validateIssue(issue, target)) ++count;
+  //   }
+  //   core.info(key + ' ' + count.toString());
+  //   members.set(key, count);
+  // });
 
   // determine team member with fewest assigned issues/PRs
   let winner = '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,8 @@ async function run() {
     const { data } = await octokit.rest.issues.listForRepo({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
-      assignee: key
+      assignee: key,
+      per_page: 100,
     });
     let count: number = 0;
     for (const issue of data) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,21 +5,8 @@ async function run() {
   const token = core.getInput('github-token');
   const team = core.getInput('team');
   const exemptTeam = core.getInput('exempt-team', { required: false });
-  const octokit = github.getOctokit(token);
-
-  // set issue type to count
-  const thisIssueData = await octokit.rest.issues.get({
-    owner: github.context.repo.owner,
-    repo: github.context.repo.repo,
-    issue_number: github.context.issue.number,
-  });
-  let target = '';
-  if (thisIssueData.data.pull_request) {
-    target = 'pull_requests';
-  } else {
-    target = 'issues';
-  }
-
+  const octokit = github.getOctokit(token);  
+  
   // Check if issue was submitted by exempt team member
   if (exemptTeam) {
     const exemptMemberData = await octokit.rest.teams.listMembersInOrg({
@@ -32,6 +19,19 @@ async function run() {
         return;
       }
     }
+  }
+
+  // set issue type to count
+  const thisIssueData = await octokit.rest.issues.get({
+    owner: github.context.repo.owner,
+    repo: github.context.repo.repo,
+    issue_number: github.context.issue.number,
+  });
+  let target = '';
+  if (thisIssueData.data.pull_request) {
+    target = 'pull_requests';
+  } else {
+    target = 'issues';
   }
 
   // get list of members on team
@@ -56,25 +56,9 @@ async function run() {
     for (const issue of data) {
       if (validateIssue(issue, target)) ++count;
     }
-    core.info(key + ' ' + count.toString());
+    core.info(key + ' has ' + count.toString() + ' ' + target + ' assigned to them.');
     members.set(key, count);
   }
-
-  // get number of issues/PRs assigned per team member
-  // members.forEach(async (value: number, key: string) => {
-  //   const { data } = await octokit.rest.issues.listForRepo({
-  //     owner: github.context.repo.owner,
-  //     repo: github.context.repo.repo,
-  //     assignee: key,
-  //     per_page: 100,
-  //   });
-  //   let count: number = 0;
-  //   for (const issue of data) {
-  //     if (validateIssue(issue, target)) ++count;
-  //   }
-  //   core.info(key + ' ' + count.toString());
-  //   members.set(key, count);
-  // });
 
   // determine team member with fewest assigned issues/PRs
   let winner = '';


### PR DESCRIPTION
Now fetches up to 100 issues / prs assigned to each member of team.

This introduces a bug which can cause the wrong person to be assigned if more than 100 issues/PRs combined are assigned to multiple people. Action will need to call as many requests as necessary until it has checked every issue/PR assigned to every user. It can do this by iterating through as many `page`s until you get to an issue count returned of anything but 100 from the [listForRepo call](https://docs.github.com/en/rest/issues/issues#list-repository-issues). However, that's something to fix for another time